### PR TITLE
fix: timetable refreshes when spot added

### DIFF
--- a/seoul_ro/lib/bloc/timetable_bloc.dart
+++ b/seoul_ro/lib/bloc/timetable_bloc.dart
@@ -3,13 +3,16 @@ import 'package:seoul_ro/bloc/timetable_event.dart';
 import 'package:seoul_ro/bloc/timetable_state.dart';
 import 'package:seoul_ro/models/spot.dart';
 
-
 class TimetableBloc extends Bloc<TimetableEvent, TimetableState> {
   List<Spot> spots = List.empty(growable: true);
+
   TimetableBloc() : super(EmptyTimetableState()) {
     on<SpotAdded>((event, emit) {
       spots.add(event.spot);
-      emit(FullTimetableState(spots));
+
+      List<Spot> newSpots = [...spots];
+
+      emit(FullTimetableState(newSpots));
     });
   }
 }


### PR DESCRIPTION
Resolves #38

Timetable에 일정을 추가해도 refresh가 되지 않아 그려지지 않는 문제를 해결했습니다.

https://bloclibrary.dev/#/faqs?id=state-not-updating
여기에 나오듯, 다른 object를 emit해야하는데 그렇게 하지 않아서 발생한 문제였습니다.
해결방법은 deep copy 하기 였습니다.